### PR TITLE
Adding an EOL to print pre to make it a little cleaner in view_source

### DIFF
--- a/include/common_funcs.php
+++ b/include/common_funcs.php
@@ -10,7 +10,7 @@
  * @return string
  */
 function print_pre($obj, $buffer=false, $tag="pre") {
-  $buf = "<$tag>print_pre: " . print_r($obj, true) . "</$tag>";
+  $buf = "<$tag>print_pre: " . print_r($obj, true) . "</$tag>" . PHP_EOL;
   if (!$buffer)
     print $buf;
   return $buf;


### PR DESCRIPTION
Very simple change, just makes each print_pre call output a PHP_EOL at the end.
