### PR TITLE
Fixing localconfig caching issues in configmanager class

### DIFF
--- a/include/app_class.php
+++ b/include/app_class.php
@@ -82,8 +82,7 @@ class App {
           $this->debug = $_SESSION["debug"];
         }
         $this->cobrand = $this->GetRequestedConfigName($this->request);
-        $skipCache = $this->cfg->isLocalConfigEnabled();
-        $this->cfg->GetConfig($this->cobrand, true, $this->cfg->role, $skipCache);
+        $this->cfg->GetConfig($this->cobrand, true, $this->cfg->role);
         $this->ApplyConfigOverrides();
         $this->locations = DependencyManager::$locations = $this->cfg->locations;
 


### PR DESCRIPTION
adding cachekey generation function, hopefully I referenced all the spots in the configmanager class where it's needed.

adding an invalidate cache function, although it turned out to not be needed for localconfig at this time when I was testing without using this function. It made sense at the time, now I can't remember why this still works.
