### PR TITLE
Adding support for redirects.xml to use cobrand-default instead of cobrand

### DIFF
--- a/include/app_class.php
+++ b/include/app_class.php
@@ -336,6 +336,7 @@ class App {
     if (empty($req))
       $req = $this->request;
 
+    //default cobrand from redirects.xml is stored in the request as "cobrand-default"
     if (!empty($req["args"]["cobrand-default"]) && is_string($req["args"]["cobrand-default"])) {
       $ret = $req["args"]["cobrand-default"];
     }


### PR DESCRIPTION
This change is to allow redirects.xml to specify cobrand-default instead of cobrand. This allows default cobrands and overriden cobrands to be differentiated
