### PR TITLE
clone: dont pass undefined to elation.util.any

### DIFF
--- a/components/utils/scripts/events.js
+++ b/components/utils/scripts/events.js
@@ -415,9 +415,9 @@ elation.extend("events", {
     var newev = {};
     for (let i = 0; i < this.cloneattrs.length; i++) {
       let attr = this.cloneattrs[i];
-      let foo = elation.utils.any(overrides[attr], ev[attr]);
-      if (foo !== null) {
-        newev[attr] = foo;
+      let val = overrides && overrides[attr] != undefined ? overrides[attr] : ev[attr]
+      if (val !== null) {
+        newev[attr] = val;
       }
     }
     return elation.events.fix(newev);


### PR DESCRIPTION
my janusweb build gave this error in the browser console (after partially loading the default room):

```
janusweb.js:3194 Uncaught TypeError: Cannot read properties of undefined (reading 'type')
    at Object.clone (janusweb.js:3194:44)
    at elation.engine.things.janusplayer.dispatchEvent (janusweb.js:149346:33)
    at elation.engine.things.janusghost.dispatchEvent (janusweb.js:123315:21)
    at Object.origin (janusweb.js:122274:61)
    at Object.fireEvent (janusweb.js:2906:22)
    at Object.fire (janusweb.js:2788:27)
    at elation.engine.things.janusghost.applyChanges (janusweb.js:88249:20)
    at janusweb.js:97054:19
    at Set.forEach (<anonymous>)
    at Object.engine_frame (janusweb.js:97051:25)
```

> NOTE: not sure if this is a bug of utils.any (I dont know to much about it), so I just did this oneliner fix. Should we fix utils.any() instead? (if so in which file?)

more context:

```
$ grep version node_modules/*/package.json
node_modules/cyclone-physics/package.json:  "version": "1.1.3",
node_modules/elation-engine/package.json:  "version": "0.9.120",
node_modules/elation/package.json:  "version": "2.3.24",
node_modules/elation-share/package.json:  "version": "1.0.9",
node_modules/uglify-js/package.json:  "version": "3.19.3",

```