### PR TITLE
android fix for input

### DIFF
--- a/components/elements/scripts/ui/input.js
+++ b/components/elements/scripts/ui/input.js
@@ -12,6 +12,7 @@ elation.require(['elements.elements'], function() {
    * @param {string} args.value
    * @param {string} args.inputname
    * @param {string} args.placeholder
+   * @param {string} args.enterkeyhint
    * @param {boolean} args.disabled
    * @param {boolean} args.hidden
    * @param {boolean} args.autofocus
@@ -30,6 +31,7 @@ elation.require(['elements.elements'], function() {
         label: { type: 'string' },
         type: { type: 'string' },
         placeholder: { type: 'string' },
+        enterkeyhint: { type: 'string', default:"enter" },
         value: { type: 'string', get: this.getValue, set: this.setValue },
         disabled: { type: 'boolean', default: false },
         autofocus: { type: 'boolean', get: this.getAutofocus, set: this.setAutofocus },
@@ -62,6 +64,8 @@ elation.require(['elements.elements'], function() {
       if (this.placeholder) {
         this.inputelement.placeholder = this.placeholder;
       }
+
+      this.inputelement.enterkeyhint = this.enterkeyhint;
 
       let value = this.value;
       elation.events.add(this, 'keydown', this.handlekeydown.bind(this));


### PR DESCRIPTION
similar to the oculus browser fix, but slightly different: 

This fix hints '**enter**' to android onscreen keyboard's via [enterkeyhint](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/enterkeyhint).<br>
Normally the default value is <b>"next"</b> which is convenient for forms (focus on next input element).
However with <b>enter</b> now:

* `accept` event is fired (which various ui elements depend on)
* more important: the urlbar in janusweb now works for android smartphone (touch) users

> users were able to type into the urlbar on android, but the onscreen keyboard would show 'next' as an enter-key..resulting in focusing the chatbox (not launching a portal)