### PR TITLE
ui.popupbutton: reposition when popup content resizes

### DIFF
--- a/components/elements/scripts/ui/popupbutton.js
+++ b/components/elements/scripts/ui/popupbutton.js
@@ -70,6 +70,15 @@ elation.require(['elements.ui.button'], function() {
       window.addEventListener('click', this.windowClickHandler);
       window.addEventListener('resize', this.windowResizeHandler);
       window.addEventListener('scroll', this.windowResizeHandler, true);
+      // Reposition when the popup's own content changes size — an expanding
+      // section, or children that render/upgrade asynchronously, grow the popup
+      // after the initial placement, and window resize/scroll alone don't cover
+      // that. ResizeObserver also fires once when first observed, which settles
+      // the initial async layout without a manual re-place.
+      if (window.ResizeObserver) {
+        this.popupResizeObserver = new ResizeObserver(() => this.positionPopup());
+        this.popupResizeObserver.observe(this.popup);
+      }
       this.positionPopup();
     }
     showPopup() {


### PR DESCRIPTION
A popup was only re-placed on **window** resize/scroll. If the popup's *own* content grows after it opens — an expanding section, or children that render/upgrade asynchronously — it stayed at its first-measured position and could sit half offscreen until some unrelated resize/scroll happened to fire `positionPopup()` again.

Fix: observe the popup with a `ResizeObserver` in `createPopup()` and call `positionPopup()` on content size change. `ResizeObserver` also fires once when first observing, so this additionally settles the initial async layout (no manual re-place needed).

## Surfaced by
JanusWeb's VOIP device picker (`janus-voip-picker` inside a `janus-button-voip` popup): it opens near the bottom-left comms bar, and clicking "with a mic" expands a section downward — previously it grew off-screen until you resized/scrolled the window. Also lets the JanusWeb invite popup drop a `setTimeout`-based reposition workaround.

## Risk
Additive and self-contained; guarded on `window.ResizeObserver`. `positionPopup()` already no-ops when the popup is detached, so the observer is harmless while a popup is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)